### PR TITLE
Add BLE keyboard input and OLED feedback

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -18,7 +18,13 @@ framework = arduino
 monitor_speed = 115200
 upload_speed = 921600
 build_flags =
-	-D ARDUINO_USB_MODE=1
-	-D ARDUINO_USB_CDC_ON_BOOT=1
+        -D ARDUINO_USB_MODE=1
+        -D ARDUINO_USB_CDC_ON_BOOT=1
+
+lib_deps =
+    t-vk/ESP32 BLE Keyboard@^0.3.2
+    t-vk/ESP32 BLE Mouse@^0.3.1
+    adafruit/Adafruit SSD1306@^2.5.7
+    adafruit/Adafruit GFX Library@^1.11.9
 
 monitor_filters = colorize, esp32_exception_decoder, send_on_enter

--- a/src/config/pins.h
+++ b/src/config/pins.h
@@ -8,24 +8,17 @@
 // Analog Inputs --------
 #define PIN_KNOB 0 // GPIO0 / ADC1_0
 
-#define PIN_KEY_0 3
-#define PIN_KEY_1 4
-#define PIN_KEY_2 7
-#define PIN_KEY_3 10
-#define PIN_KEY_4 20
-#define PIN_KEY_5 21
-
 // Analog Outputs --------
 #define PIN_ENC_A 0
 #define PIN_ENC_B 1
 
-// Button input pins ---------
-#define PIN_BUTTON_1 2
-#define PIN_BUTTON_2 3
-#define PIN_BUTTON_3 4
-#define PIN_BUTTON_4 5
-#define PIN_BUTTON_5 9
-#define PIN_BUTTON_6 10
+// Digital Inputs --------
+#define PIN_BUTTON_1 3
+#define PIN_BUTTON_2 4
+#define PIN_BUTTON_3 7
+#define PIN_BUTTON_4 10
+#define PIN_BUTTON_5 20
+#define PIN_BUTTON_6 21
 
 // I2C pins ---------------
 #define PIN_SDA 5 // GPIO5

--- a/src/config/pins.h
+++ b/src/config/pins.h
@@ -9,10 +9,11 @@
 #define PIN_KNOB 0 // GPIO0 / ADC1_0
 
 // Analog Outputs --------
+
+// Digital Inputs --------
 #define PIN_ENC_A 0
 #define PIN_ENC_B 1
 
-// Digital Inputs --------
 #define PIN_BUTTON_1 3
 #define PIN_BUTTON_2 4
 #define PIN_BUTTON_3 7

--- a/src/config/pins.h
+++ b/src/config/pins.h
@@ -15,6 +15,14 @@
 #define PIN_ADC_0 0
 #define PIN_ADC_1 1
 
+// Button input pins ---------
+#define PIN_BUTTON_1 2
+#define PIN_BUTTON_2 3
+#define PIN_BUTTON_3 4
+#define PIN_BUTTON_4 5
+#define PIN_BUTTON_5 9
+#define PIN_BUTTON_6 10
+
 // I2C pins ---------------
 #define PIN_SCL 7
 #define PIN_SDA 6

--- a/src/src.cpp
+++ b/src/src.cpp
@@ -29,6 +29,38 @@ const uint8_t buttonPins[] = {
 
 bool lastState[6];
 
+// Rotary encoder state
+volatile int encoderState = 1; // valid range 1-7
+volatile int lastEncoded = 0;
+volatile bool encoderMoved = false;
+
+void IRAM_ATTR updateEncoder()
+{
+    int msb = digitalRead(PIN_ENC_A);
+    int lsb = digitalRead(PIN_ENC_B);
+    int encoded = (msb << 1) | lsb;
+    int sum = (lastEncoded << 2) | encoded;
+
+    if (sum == 0b1101 || sum == 0b0100 || sum == 0b0010 || sum == 0b1011)
+    {
+        if (encoderState < 7)
+        {
+            encoderState++;
+            encoderMoved = true;
+        }
+    }
+    else if (sum == 0b1110 || sum == 0b0111 || sum == 0b0001 || sum == 0b1000)
+    {
+        if (encoderState > 1)
+        {
+            encoderState--;
+            encoderMoved = true;
+        }
+    }
+
+    lastEncoded = encoded;
+}
+
 void setup()
 {
     Serial.begin(115200);
@@ -40,6 +72,13 @@ void setup()
         pinMode(buttonPins[i], INPUT_PULLUP);
         lastState[i] = false;
     }
+
+    // Initialize rotary encoder pins and interrupts
+    pinMode(PIN_ENC_A, INPUT_PULLUP);
+    pinMode(PIN_ENC_B, INPUT_PULLUP);
+    lastEncoded = (digitalRead(PIN_ENC_A) << 1) | digitalRead(PIN_ENC_B);
+    attachInterrupt(digitalPinToInterrupt(PIN_ENC_A), updateEncoder, CHANGE);
+    attachInterrupt(digitalPinToInterrupt(PIN_ENC_B), updateEncoder, CHANGE);
 
     // Initialize I2C and display
     Wire.begin(PIN_SDA, PIN_SCL);
@@ -78,6 +117,22 @@ void loop()
             }
             lastState[i] = pressed;
         }
+    }
+
+    if (encoderMoved)
+    {
+        noInterrupts();
+        int value = encoderState;
+        encoderMoved = false;
+        interrupts();
+
+        display.clearDisplay();
+        display.setTextSize(2);
+        display.setTextColor(SSD1306_WHITE);
+        display.setCursor(0, 0);
+        display.print("State ");
+        display.print(value);
+        display.display();
     }
     delay(10);
 }

--- a/src/src.cpp
+++ b/src/src.cpp
@@ -1,29 +1,80 @@
-
 #include <Arduino.h>
 #include "define.h"
 
-// This is to hide non-test related source code.
-// https://docs.platformio.org/en/latest/plus/unit-testing.html
+#include <BleKeyboard.h>
+#include <BleMouse.h>
+#include <Wire.h>
+#include <Adafruit_GFX.h>
+#include <Adafruit_SSD1306.h>
+
 #ifndef UNIT_TEST
 
+// BLE peripherals
+BleKeyboard bleKeyboard("Mini Key Drive");
+BleMouse bleMouse("Mini Key Drive");
+
+// OLED display configuration
+#define SCREEN_WIDTH 128
+#define SCREEN_HEIGHT 32
+Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, -1);
+
+// Button pins - defined in pins.h
+const uint8_t buttonPins[] = {
+    PIN_BUTTON_1,
+    PIN_BUTTON_2,
+    PIN_BUTTON_3,
+    PIN_BUTTON_4,
+    PIN_BUTTON_5,
+    PIN_BUTTON_6
+};
+
+bool lastState[6];
+
 void setup() {
-    // put your setup code here, to run once:
-
-    // Enables Serial Communication with baudRate of 115200
     Serial.begin(115200);
-    Serial.println("PlatformIO ESP32 Boilerplate started...");
+    Serial.println("Mini Bluetooth Key Drive starting...");
 
-    pinMode(PIN_LED_INBUILT, OUTPUT);
+    // Initialize button pins with pull-ups
+    for (size_t i = 0; i < 6; i++) {
+        pinMode(buttonPins[i], INPUT_PULLUP);
+        lastState[i] = false;
+    }
+
+    // Initialize I2C and display
+    Wire.begin(PIN_SDA, PIN_SCL);
+    if (!display.begin(SSD1306_SWITCHCAPVCC, 0x3C)) {
+        Serial.println("SSD1306 allocation failed");
+    }
+    display.clearDisplay();
+    display.display();
+
+    // Start BLE services
+    bleKeyboard.begin();
+    bleMouse.begin();
 }
 
 void loop() {
-    // put your main code here, to run repeatedly:
+    if (bleKeyboard.isConnected()) {
+        for (size_t i = 0; i < 6; i++) {
+            bool pressed = digitalRead(buttonPins[i]) == LOW;
+            if (pressed && !lastState[i]) {
+                // Send number keystroke corresponding to button
+                bleKeyboard.write('1' + i);
 
-    digitalWrite(PIN_LED_INBUILT, HIGH);
-    delay(1000);
-    digitalWrite(PIN_LED_INBUILT, LOW);
-    delay(1000);
-
+                // Show pressed button on OLED
+                display.clearDisplay();
+                display.setTextSize(2);
+                display.setTextColor(SSD1306_WHITE);
+                display.setCursor(0, 0);
+                display.print("Button ");
+                display.print(i + 1);
+                display.display();
+            }
+            lastState[i] = pressed;
+        }
+    }
+    delay(10);
 }
 
-#endif
+#endif // UNIT_TEST
+


### PR DESCRIPTION
## Summary
- integrate BLE keyboard and mouse libraries and send number keystrokes for six buttons
- display pressed button number on 128x32 SSD1306 OLED via I2C
- declare button pin mappings and add required library dependencies

## Testing
- `pio run` *(fails: command not found)*
- `pip install platformio` *(fails: 403 Forbidden when fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_6892e7b8d17083269ada7ddef9eb32d3