### PR TITLE
Add rotary encoder handling with display

### DIFF
--- a/src/src.cpp
+++ b/src/src.cpp
@@ -29,6 +29,38 @@ const uint8_t buttonPins[] = {
 
 bool lastState[6];
 
+// Rotary encoder state
+volatile int encoderState = 1; // valid range 1-7
+volatile int lastEncoded = 0;
+volatile bool encoderMoved = false;
+
+void IRAM_ATTR updateEncoder()
+{
+    int msb = digitalRead(PIN_ENC_A);
+    int lsb = digitalRead(PIN_ENC_B);
+    int encoded = (msb << 1) | lsb;
+    int sum = (lastEncoded << 2) | encoded;
+
+    if (sum == 0b1101 || sum == 0b0100 || sum == 0b0010 || sum == 0b1011)
+    {
+        if (encoderState < 7)
+        {
+            encoderState++;
+            encoderMoved = true;
+        }
+    }
+    else if (sum == 0b1110 || sum == 0b0111 || sum == 0b0001 || sum == 0b1000)
+    {
+        if (encoderState > 1)
+        {
+            encoderState--;
+            encoderMoved = true;
+        }
+    }
+
+    lastEncoded = encoded;
+}
+
 void setup()
 {
     Serial.begin(115200);
@@ -40,6 +72,13 @@ void setup()
         pinMode(buttonPins[i], INPUT_PULLUP);
         lastState[i] = false;
     }
+
+    // Initialize rotary encoder pins and interrupts
+    pinMode(PIN_ENC_A, INPUT_PULLUP);
+    pinMode(PIN_ENC_B, INPUT_PULLUP);
+    lastEncoded = (digitalRead(PIN_ENC_A) << 1) | digitalRead(PIN_ENC_B);
+    attachInterrupt(digitalPinToInterrupt(PIN_ENC_A), updateEncoder, CHANGE);
+    attachInterrupt(digitalPinToInterrupt(PIN_ENC_B), updateEncoder, CHANGE);
 
     // Initialize I2C and display
     Wire.begin(PIN_SDA, PIN_SCL);
@@ -78,6 +117,22 @@ void loop()
             }
             lastState[i] = pressed;
         }
+    }
+
+    if (encoderMoved)
+    {
+        noInterrupts();
+        int value = encoderState;
+        encoderMoved = false;
+        interrupts();
+
+        display.clearDisplay();
+        display.setTextSize(2);
+        display.setTextColor(SSD1306_WHITE);
+        display.setCursor(0, 0);
+        display.print("State ");
+        display.print(value);
+        display.display();
     }
     delay(10);
 }


### PR DESCRIPTION
## Summary
- handle two-pin rotary encoder with pin change interrupts
- track encoder state 1-7 and render on OLED when rotated

## Testing
- `pio test` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_6893028323b48326a71b6a0da692785d